### PR TITLE
Add support for importing components from component directory (i.e. "…

### DIFF
--- a/snippets/accordion.code-snippets
+++ b/snippets/accordion.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Accordion } from 'react-bootstrap';",
     "description": "Import Accordion from react-bootstrap"
   },
+  "Import Accordion Only": {
+    "prefix": "rb:import:only:accordion",
+    "body": "import Accordion from 'react-bootstrap/Accordion';",
+    "description": "Import Accordion from react-bootstrap/Accordion"
+  },
   "Accordion": {
     "prefix": "rb:accordion",
     "body": ["<Accordion>", "\t${2:Accordion.Item, Card, etc}", "</Accordion>"],

--- a/snippets/alerts.code-snippets
+++ b/snippets/alerts.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Alert } from 'react-bootstrap';",
     "description": "Import Alert from react-bootstrap"
   },
+  "Import Alert Only": {
+    "prefix": "rb:import:only:alert",
+    "body": "import Alert from 'react-bootstrap/Alert';",
+    "description": "Import Alert from react-bootstrap/Alert"
+  },
   "Alert (primary)": {
     "prefix": ["rb:alert", "rb:alert-primary"],
     "body": [

--- a/snippets/badge.code-snippets
+++ b/snippets/badge.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Badge } from 'react-bootstrap';",
     "description": "Import Badge from react-bootstrap"
   },
+  "Import Badge Only": {
+    "prefix": "rb:import:only:badge",
+    "body": "import Badge from 'react-bootstrap/Badge';",
+    "description": "Import Badge from react-bootstrap/Badge"
+  },
   "Badge (primary)": {
     "prefix": ["rb:badge", "rb:badge-primary"],
     "body": ["<Badge bg=\"primary\">${1:Primary}</Badge>"],

--- a/snippets/breadcrumb.code-snippets
+++ b/snippets/breadcrumb.code-snippets
@@ -1,4 +1,14 @@
 {
+  "Import Breadcrumb": {
+    "prefix": "rb:import:breadcrumb",
+    "body": "import { Breadcrumb } from 'react-bootstrap';",
+    "description": "Import Breadcrumb from react-bootstrap"
+  },
+  "Import Breadcrumb Only": {
+    "prefix": "rb:import:only:breadcrumb",
+    "body": "import Breadcrumb from 'react-bootstrap/Breadcrumb';",
+    "description": "Import Breadcrumb from react-bootstrap/Breadcrumb"
+  },
   "Breadcrumb": {
     "prefix": "rb:breadcrumb",
     "body": [

--- a/snippets/button-group.code-snippets
+++ b/snippets/button-group.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { ButtonGroup } from 'react-bootstrap';",
     "description": "Import ButtonGroup from react-bootstrap"
   },
+  "Import ButtonGroup Only": {
+    "prefix": "rb:import:only:button-group",
+    "body": "import ButtonGroup from 'react-bootstrap/ButtonGroup';",
+    "description": "Import ButtonGroup from react-bootstrap/ButtonGroup"
+  },
   "ButtonGroup": {
     "prefix": "rb:button-group",
     "body": ["<ButtonGroup>${1:Buttons}</ButtonGroup>"],
@@ -24,6 +29,11 @@
     "prefix": "rb:import:button-toolbar",
     "body": "import { ButtonToolbar } from 'react-bootstrap';",
     "description": "Import ButtonToolbar from react-bootstrap"
+  },
+  "Import ButtonToolbar Only": {
+    "prefix": "rb:import:only:button-toolbar",
+    "body": "import ButtonToolbar from 'react-bootstrap/ButtonToolbar';",
+    "description": "Import ButtonToolbar from react-bootstrap/ButtonToolbar"
   },
   "ButtonToolbar": {
     "prefix": "rb:button-toolbar",

--- a/snippets/buttons.code-snippets
+++ b/snippets/buttons.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Button } from 'react-bootstrap';",
     "description": "Import Button from react-bootstrap"
   },
+  "Import Button Only": {
+    "prefix": "rb:import:only:button",
+    "body": "import Button from 'react-bootstrap/Button';",
+    "description": "Import Button from react-bootstrap/Button"
+  },
   "Button (primary)": {
     "prefix": ["rb:button", "rb:button-primary"],
     "body": [
@@ -500,6 +505,11 @@
     "body": "import { ToggleButton } from 'react-bootstrap';",
     "description": "Import ToggleButton from react-bootstrap"
   },
+  "Import ToggleButton Only": {
+    "prefix": "rb:import:only:toggle-button",
+    "body": "import ToggleButton from 'react-bootstrap/ToggleButton';",
+    "description": "Import ToggleButton from react-bootstrap/ToggleButton"
+  },
   "ToggleButton": {
     "prefix": "rb:toggle-button",
     "body": [
@@ -511,6 +521,11 @@
     "prefix": "rb:import:toggle-button-group",
     "body": "import { ToggleButtonGroup } from 'react-bootstrap';",
     "description": "Import ToggleButtonGroup from react-bootstrap"
+  },
+  "Import ToggleButtonGroup Only": {
+    "prefix": "rb:import:only:toggle-button-group",
+    "body": "import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';",
+    "description": "Import ToggleButtonGroup from react-bootstrap/ToggleButtonGroup"
   },
   "Radio ToggleButtonGroup": {
     "prefix": ["rb:toggle-button-group", "rb:toggle-button-group-radio"],

--- a/snippets/cards.code-snippets
+++ b/snippets/cards.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Card } from 'react-bootstrap';",
     "description": "Import Card from react-bootstrap"
   },
+  "Import Card Only": {
+    "prefix": "rb:import:only:card",
+    "body": "import Card from 'react-bootstrap/Card';",
+    "description": "Import Card from react-bootstrap/Card"
+  },
   "Card": {
     "prefix": "rb:card",
     "body": [
@@ -97,6 +102,11 @@
     "prefix": "rb:import:card-group",
     "body": "import { CardGroup } from 'react-bootstrap';",
     "description": "Import CardGroup from react-bootstrap"
+  },
+  "Import CardGroup Only": {
+    "prefix": "rb:import:only:card-group",
+    "body": "import CardGroup from 'react-bootstrap/CardGroup';",
+    "description": "Import CardGroup from react-bootstrap/CardGroup"
   },
   "CardGroup": {
     "prefix": "rb:card-group",

--- a/snippets/carousel.code-snippets
+++ b/snippets/carousel.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Carousel } from 'react-bootstrap';",
     "description": "Import Carousel from react-bootstrap"
   },
+  "Import Carousel Only": {
+    "prefix": "rb:import:only:carousel",
+    "body": "import Carousel from 'react-bootstrap/Carousel';",
+    "description": "Import Carousel from react-bootstrap/Carousel"
+  },
   "Carousel": {
     "prefix": "rb:carousel",
     "body": ["<Carousel>${1:Carousel items}</Carousel>"],

--- a/snippets/close-button.code-snippets
+++ b/snippets/close-button.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { CloseButton } from 'react-bootstrap';",
     "description": "Import CloseButton from react-bootstrap"
   },
+  "Import CloseButton Only": {
+    "prefix": "rb:import:only:close-button",
+    "body": "import CloseButton from 'react-bootstrap/CloseButton';",
+    "description": "Import CloseButton from react-bootstrap/CloseButton"
+  },
   "CloseButton (dark)": {
     "prefix": ["rb:close-button", "rb:close-button-dark"],
     "body": ["<CloseButton onClick={${1:() => console.log(\"Close\")}} />"],

--- a/snippets/dropdowns.code-snippets
+++ b/snippets/dropdowns.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Dropdown, DropdownButton } from 'react-bootstrap';",
     "description": "Import DropdownButton and Dropdown from react-bootstrap"
   },
+  "Import DropdownButton Only": {
+    "prefix": "rb:import:only:dropdown-button",
+    "body": "import Dropdown from 'react-bootstrap/Dropdown';\nimport DropdownButton from 'react-bootstrap/DropdownButton';",
+    "description": "Import DropdownButton and Dropdown separately from react-bootstrap"
+  },
   "DropdownButton": {
     "prefix": "rb:dropdown-button",
     "body": [
@@ -18,6 +23,11 @@
     "body": "import { Dropdown, SplitButton } from 'react-bootstrap';",
     "description": "Import SplitButton and Dropdown from react-bootstrap"
   },
+  "Import SplitButton Only": {
+    "prefix": ["rb:import:only:dropdown-split-button"],
+    "body": "import Dropdown from 'react-bootstrap/Dropdown';\nimport SplitButton from 'react-bootstrap/SplitButton';",
+    "description": "Import SplitButton and Dropdown separately from react-bootstrap"
+  },
   "SplitButton": {
     "prefix": ["rb:dropdown-split-button"],
     "body": [
@@ -31,6 +41,11 @@
     "prefix": "rb:import:dropdown",
     "body": "import { Dropdown } from 'react-bootstrap';",
     "description": "Import Dropdown from react-bootstrap"
+  },
+  "Import Dropdown Only": {
+    "prefix": "rb:import:only:dropdown",
+    "body": "import Dropdown from 'react-bootstrap/Dropdown';",
+    "description": "Import Dropdown from react-bootstrap/Dropdown"
   },
   "Dropdown": {
     "prefix": "rb:dropdown",

--- a/snippets/figures.code-snippets
+++ b/snippets/figures.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Figure } from 'react-bootstrap';",
     "description": "Import Figure from react-bootstrap"
   },
+  "Import Figure Only": {
+    "prefix": "rb:import:only:figure",
+    "body": "import Figure from 'react-bootstrap/Figure';",
+    "description": "Import Figure from react-bootstrap/Figure"
+  },
   "Figure": {
     "prefix": "rb:figure",
     "body": [

--- a/snippets/forms.code-snippets
+++ b/snippets/forms.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Form } from 'react-bootstrap';",
     "description": "Import Form from react-bootstrap"
   },
+  "Import Form Only": {
+    "prefix": "rb:import:only:form",
+    "body": "import Form from 'react-bootstrap/Form';",
+    "description": "Import Form from react-bootstrap/Form"
+  },
   "Form": {
     "prefix": "rb:form",
     "body": ["<Form>", "\t${1:Form.Group, Row, etc}", "</Form>"],
@@ -22,6 +27,11 @@
     "prefix": "rb:import:form-floating-label",
     "body": "import { FloatingLabel } from 'react-bootstrap';",
     "description": "Import FloatingLabel from react-bootstrap"
+  },
+  "Import FloatingLabel Only": {
+    "prefix": "rb:import:only:form-floating-label",
+    "body": "import FloatingLabel from 'react-bootstrap/FloatingLabel';",
+    "description": "Import FloatingLabel from react-bootstrap/FloatingLabel"
   },
   "FloatingLabel": {
     "prefix": "rb:form-floating-label",

--- a/snippets/grid.code-snippets
+++ b/snippets/grid.code-snippets
@@ -4,10 +4,20 @@
     "body": "import { Container, Row, Col } from 'react-bootstrap';",
     "description": "Import grid components Container, Row, and Col from react-bootstrap"
   },
+  "Import Grid Only (Container, Row, Col)": {
+    "prefix": ["rb:import:only:grid", "rb:import:only:grid-container-row-col"],
+    "body": "import Container from 'react-bootstrap/Container';\nimport Row from 'react-bootstrap/Row';, import Col from 'react-bootstrap/Col';",
+    "description": "Import grid components Container, Row, and Col separately from react-bootstrap"
+  },
   "Import Container": {
     "prefix": "rb:import:container",
     "body": "import { Container } from 'react-bootstrap';",
     "description": "Import Container from react-bootstrap"
+  },
+  "Import Container Only": {
+    "prefix": "rb:import:only:container",
+    "body": "import Container from 'react-bootstrap/Container';",
+    "description": "Import Container from react-bootstrap/Container"
   },
   "Container": {
     "prefix": "rb:container",
@@ -23,6 +33,11 @@
     "prefix": "rb:import:row",
     "body": "import { Row } from 'react-bootstrap';",
     "description": "Import Row from react-bootstrap"
+  },
+  "Import Row Only": {
+    "prefix": "rb:import:only:row",
+    "body": "import Row from 'react-bootstrap/Row';",
+    "description": "Import Row from react-bootstrap/Row"
   },
   "Row": {
     "prefix": "rb:row",
@@ -63,6 +78,11 @@
     "prefix": "rb:import:col",
     "body": "import { Col } from 'react-bootstrap';",
     "description": "Import Col from react-bootstrap"
+  },
+  "Import Col Only": {
+    "prefix": "rb:import:only:col",
+    "body": "import Col from 'react-bootstrap/Col';",
+    "description": "Import Col from react-bootstrap/Col"
   },
   "Col": {
     "prefix": "rb:col",

--- a/snippets/images.code-snippets
+++ b/snippets/images.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Image } from 'react-bootstrap';",
     "description": "Import Image from react-bootstrap"
   },
+  "Import Image Only": {
+    "prefix": "rb:import:only:image",
+    "body": "import Image from 'react-bootstrap/Image';",
+    "description": "Import Image from react-bootstrap/Image"
+  },
   "Image": {
     "prefix": "rb:image",
     "body": ["<Image src=\"${1:https://placeimg.com/171/180/any}\" />"],

--- a/snippets/input-group.code-snippets
+++ b/snippets/input-group.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { InputGroup } from 'react-bootstrap';",
     "description": "Import InputGroup from react-bootstrap"
   },
+  "Import InputGroup Only": {
+    "prefix": "rb:import:only:input-group",
+    "body": "import InputGroup from 'react-bootstrap/InputGroup';",
+    "description": "Import InputGroup from react-bootstrap/InputGroup"
+  },
   "InputGroup": {
     "prefix": "rb:input-group",
     "body": [

--- a/snippets/list-group.code-snippets
+++ b/snippets/list-group.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { ListGroup } from 'react-bootstrap';",
     "description": "Import ListGroup from react-bootstrap"
   },
+  "Import ListGroup Only": {
+    "prefix": "rb:import:only:list-group",
+    "body": "import ListGroup from 'react-bootstrap/ListGroup';",
+    "description": "Import ListGroup from react-bootstrap/ListGroup"
+  },
   "ListGroup": {
     "prefix": "rb:list-group",
     "body": [

--- a/snippets/modal.code-snippets
+++ b/snippets/modal.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Modal } from 'react-bootstrap';",
     "description": "Import Modal from react-bootstrap"
   },
+  "Import Modal Only": {
+    "prefix": "rb:import:only:modal",
+    "body": "import Modal from 'react-bootstrap/Modal';",
+    "description": "Import Modal from react-bootstrap/Modal"
+  },
   "Modal": {
     "prefix": ["rb:modal", "rb:modal-md"],
     "body": [

--- a/snippets/navbar.code-snippets
+++ b/snippets/navbar.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Navbar } from 'react-bootstrap';",
     "description": "Import Navbar from react-bootstrap"
   },
+  "Import Navbar Only": {
+    "prefix": "rb:import:only:navbar",
+    "body": "import Navbar from 'react-bootstrap/Navbar';",
+    "description": "Import Navbar from react-bootstrap/Navbar"
+  },
   "Navbar (light)": {
     "prefix": ["rb:navbar", "rb:navbar-light"],
     "body": [

--- a/snippets/navs.code-snippets
+++ b/snippets/navs.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Nav } from 'react-bootstrap';",
     "description": "Import Nav from react-bootstrap"
   },
+  "Import Nav Only": {
+    "prefix": "rb:import:only:nav",
+    "body": "import Nav from 'react-bootstrap/Nav';",
+    "description": "Import Nav from react-bootstrap/Nav"
+  },
   "Nav": {
     "prefix": "rb:nav",
     "body": [
@@ -77,6 +82,11 @@
     "prefix": "rb:import:nav-dropdown",
     "body": "import { NavDropdown } from 'react-bootstrap';",
     "description": "Import NavDropdown from react-bootstrap"
+  },
+  "Import NavDropdown Only": {
+    "prefix": "rb:import:only:nav-dropdown",
+    "body": "import NavDropdown from 'react-bootstrap/NavDropdown';",
+    "description": "Import NavDropdown from react-bootstrap/NavDropdown"
   },
   "NavDropdown": {
     "prefix": "rb:nav-dropdown",

--- a/snippets/overlays.code-snippets
+++ b/snippets/overlays.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Overlay } from 'react-bootstrap';",
     "description": "Import Overlay from react-bootstrap"
   },
+  "Import Overlay Only": {
+    "prefix": "rb:import:only:overlay",
+    "body": "import Overlay from 'react-bootstrap/Overlay';",
+    "description": "Import Overlay from react-bootstrap/Overlay"
+  },
   "Overlay": {
     "prefix": "rb:overlay",
     "body": [
@@ -30,6 +35,11 @@
     "prefix": "rb:import:overlay-trigger",
     "body": "import { OverlayTrigger } from 'react-bootstrap';",
     "description": "Import OverlayTrigger from react-bootstrap"
+  },
+  "Import OverlayTrigger Only": {
+    "prefix": "rb:import:only:overlay-trigger",
+    "body": "import OverlayTrigger from 'react-bootstrap/OverlayTrigger';",
+    "description": "Import OverlayTrigger from react-bootstrap/OverlayTrigger"
   },
   "OverlayTrigger (Tooltip)": {
     "prefix": ["rb:overlay-trigger", "rb:overlay-trigger-tooltip"],

--- a/snippets/pagination.code-snippets
+++ b/snippets/pagination.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Pagination } from 'react-bootstrap';",
     "description": "Import Pagination from react-bootstrap"
   },
+  "Import Pagination Only": {
+    "prefix": "rb:import:only:pagination",
+    "body": "import Pagination from 'react-bootstrap/Pagination';",
+    "description": "Import Pagination from react-bootstrap/Pagination"
+  },
   "Pagination": {
     "prefix": "rb:pagination",
     "body": [

--- a/snippets/placeholders.code-snippets
+++ b/snippets/placeholders.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Placeholder } from 'react-bootstrap';",
     "description": "Import Placeholder from react-bootstrap"
   },
+  "Import Placeholder Only": {
+    "prefix": "rb:import:only:placeholder",
+    "body": "import Placeholder from 'react-bootstrap/Placeholder';",
+    "description": "Import Placeholder from react-bootstrap/Placeholder"
+  },
   "Placeholder": {
     "prefix": "rb:placeholder",
     "body": ["<Placeholder xs={${1:6}} />"],

--- a/snippets/popovers.code-snippets
+++ b/snippets/popovers.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Popover } from 'react-bootstrap';",
     "description": "Import Popover from react-bootstrap"
   },
+  "Import Popover Only": {
+    "prefix": "rb:import:only:popover",
+    "body": "import Popover from 'react-bootstrap/Popover';",
+    "description": "Import Popover from react-bootstrap/Popover"
+  },
   "Popover": {
     "prefix": "rb:popover",
     "body": [

--- a/snippets/progress.code-snippets
+++ b/snippets/progress.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { ProgressBar } from 'react-bootstrap';",
     "description": "Import ProgressBar from react-bootstrap"
   },
+  "Import ProgressBar Only": {
+    "prefix": "rb:import:only:progress-bar",
+    "body": "import ProgressBar from 'react-bootstrap/ProgressBar';",
+    "description": "Import ProgressBar from react-bootstrap/ProgressBar"
+  },
   "ProgressBar (primary)": {
     "prefix": ["rb:progress-bar", "rb:progress-bar-primary"],
     "body": ["<ProgressBar variant=\"primary\" now={${1:40}} label=\"$2\" />"],

--- a/snippets/ratio.code-snippets
+++ b/snippets/ratio.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Ratio } from 'react-bootstrap';",
     "description": "Import Ratio from react-bootstrap"
   },
+  "Import Ratio Only": {
+    "prefix": "rb:import:only:ratio",
+    "body": "import Ratio from 'react-bootstrap/Ratio';",
+    "description": "Import Ratio from react-bootstrap/Ratio"
+  },
   "Ratio (1x1)": {
     "prefix": ["rb:ratio", "rb:ratio-1x1"],
     "body": [

--- a/snippets/spinners.code-snippets
+++ b/snippets/spinners.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Spinner } from 'react-bootstrap';",
     "description": "Import Spinner from react-bootstrap"
   },
+  "Import Spinner Only": {
+    "prefix": "rb:import:only:spinner",
+    "body": "import Spinner from 'react-bootstrap/Spinner';",
+    "description": "Import Spinner from react-bootstrap/Spinner"
+  },
   "Border Spinner": {
     "prefix": ["rb:spinner", "rb:spinner-border"],
     "body": ["<Spinner animation=\"border\" role=\"status\" />"],

--- a/snippets/stack.code-snippets
+++ b/snippets/stack.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Stack } from 'react-bootstrap';",
     "description": "Import Stack from react-bootstrap"
   },
+  "Import Stack Only": {
+    "prefix": "rb:import:only:stack",
+    "body": "import Stack from 'react-bootstrap/Stack';",
+    "description": "Import Stack from react-bootstrap/Stack"
+  },
   "Vertical Stack": {
     "prefix": ["rb:stack", "rb:stack-vertical"],
     "body": ["<Stack gap={${2:2}}>", "\t${1:div, etc}", "</Stack>"],

--- a/snippets/table.code-snippets
+++ b/snippets/table.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Table } from 'react-bootstrap';",
     "description": "Import Table from react-bootstrap"
   },
+  "Import Table Only": {
+    "prefix": "rb:import:only:table",
+    "body": "import Table from 'react-bootstrap/Table';",
+    "description": "Import Table from react-bootstrap/Table"
+  },
   "Table": {
     "prefix": ["rb:table", "rb:table-striped-bordered-responsive"],
     "body": [

--- a/snippets/tabs.code-snippets
+++ b/snippets/tabs.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Tabs } from 'react-bootstrap';",
     "description": "Import Tabs from react-bootstrap"
   },
+  "Import Tabs Only": {
+    "prefix": "rb:import:only:tabs",
+    "body": "import Tabs from 'react-bootstrap/Tabs';",
+    "description": "Import Tabs from react-bootstrap/Tabs"
+  },
   "Tabs": {
     "prefix": "rb:tabs",
     "body": [
@@ -17,6 +22,11 @@
     "prefix": "rb:import:tab",
     "body": "import { Tab } from 'react-bootstrap';",
     "description": "Import Tab from react-bootstrap"
+  },
+  "Import Tab Only": {
+    "prefix": "rb:import:only:tab",
+    "body": "import Tab from 'react-bootstrap/Tab';",
+    "description": "Import Tab from react-bootstrap/Tab"
   },
   "Tab": {
     "prefix": "rb:tab",

--- a/snippets/toasts.code-snippets
+++ b/snippets/toasts.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Toast } from 'react-bootstrap';",
     "description": "Import Toast from react-bootstrap"
   },
+  "Import Toast Only": {
+    "prefix": "rb:import:only:toast",
+    "body": "import Toast from 'react-bootstrap/Toast';",
+    "description": "Import Toast from react-bootstrap/Toast"
+  },
   "Toast": {
     "prefix": "rb:toast",
     "body": ["<Toast>", "\t${1:Toast.Header, Toast.Body, etc}", "</Toast>"],

--- a/snippets/tooltips.code-snippets
+++ b/snippets/tooltips.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Tooltip } from 'react-bootstrap';",
     "description": "Import Tooltip from react-bootstrap"
   },
+  "Import Tooltip Only": {
+    "prefix": "rb:import:only:tooltip",
+    "body": "import Tooltip from 'react-bootstrap/Tooltip';",
+    "description": "Import Tooltip from react-bootstrap/Tooltip"
+  },
   "Tooltip": {
     "prefix": "rb:tooltip",
     "body": [

--- a/snippets/transitions.code-snippets
+++ b/snippets/transitions.code-snippets
@@ -4,6 +4,11 @@
     "body": "import { Collapse } from 'react-bootstrap';",
     "description": "Import Collapse from react-bootstrap"
   },
+  "Import Collapse Only": {
+    "prefix": "rb:import:only:collapse",
+    "body": "import Collapse from 'react-bootstrap/Collapse';",
+    "description": "Import Collapse from react-bootstrap/Collapse"
+  },
   "Collapse": {
     "prefix": "rb:collapse",
     "body": [
@@ -21,6 +26,11 @@
     "prefix": "rb:import:fade",
     "body": "import { Fade } from 'react-bootstrap';",
     "description": "Import Fade from react-bootstrap"
+  },
+  "Import Fade Only": {
+    "prefix": "rb:import:only:fade",
+    "body": "import Fade from 'react-bootstrap/Fade';",
+    "description": "Import Fade from react-bootstrap/Fade"
   },
   "Fade": {
     "prefix": "rb:fade",


### PR DESCRIPTION
These snippets only support the default React imports. React Bootstrap docs now prefer importing components in the following fashion:

```js
import Accordion from 'react-bootstrap/Accordion';
```
source: https://react-bootstrap.github.io/getting-started/introduction/#importing-components

This commit adds the following snippet for all current imports:

`rb:import:only:<component>`

```js

// rb:import:only:accordion
import Accordion from 'react-bootstrap/Accordion';

// rb:import:only:dropdown-button
import Dropdown from 'react-bootstrap/Dropdown';
import DropdownButton from 'react-bootstrap/DropdownButton';
```

I used 'only' as the keyword, but can edit this commit to use anything else.

This commit also adds an import for the Breadcrumb component.

\-----

P.S. Thanks for the snippets, they're great!